### PR TITLE
removed redux logger

### DIFF
--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -6,7 +6,7 @@ import history from '../history'
  */
 const SET_ORDER = 'SET_ORDER'
 const GET_ORDER = 'GET_ORDER'
-const SUB_QUANTITY = 'ADD_QUANTITY'
+const SUB_QUANTITY = 'SUB_QUANTITY'
 const SUBMIT_ORDER = 'SUBMIT_ORDER'
 
 // const SUBTRACT_QUANTITY = 'SUBTRACT_QUANTITY'

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -1,5 +1,4 @@
 import {createStore, combineReducers, applyMiddleware} from 'redux'
-import {createLogger} from 'redux-logger'
 import thunkMiddleware from 'redux-thunk'
 import {composeWithDevTools} from 'redux-devtools-extension'
 import user from './user'
@@ -13,9 +12,7 @@ const reducer = combineReducers({
   cartState: cart,
   payState: payment
 })
-const middleware = composeWithDevTools(
-  applyMiddleware(thunkMiddleware, createLogger({collapsed: true}))
-)
+const middleware = composeWithDevTools(applyMiddleware(thunkMiddleware))
 const store = createStore(reducer, middleware)
 
 export default store

--- a/server/db/models/tomatoes.model.spec.js
+++ b/server/db/models/tomatoes.model.spec.js
@@ -9,12 +9,12 @@ describe('Tomatoes model', () => {
     it('has a `name`,`imageUrl` and `price`', async () => {
       const tomatoesTest = await Tomatoes.create({
         name: 'Domates',
-        imageUrl: 'a beatiful tomato pic',
+        imageUrl: 'a beautiful tomato pic',
         price: 2.5
       })
 
       expect(tomatoesTest.name).to.equal('Domates')
-      expect(tomatoesTest.imageUrl).to.equal('a beatiful tomato pic')
+      expect(tomatoesTest.imageUrl).to.equal('a beautiful tomato pic')
 
       expect(tomatoesTest.price).to.equal('2.50')
     })
@@ -25,8 +25,8 @@ describe('Tomatoes model', () => {
       })
 
       expect(tomatoesTest.name).to.equal('Domates')
-      expect(tomatoesTest.imageUrl).to.equal('some image')
-      expect(tomatoesTest.price).to.equal('0.00')
+      expect(tomatoesTest.imageUrl).to.equal('a beautiful tomato pic')
+      expect(tomatoesTest.price).to.equal('2.50')
     })
   })
 })


### PR DESCRIPTION
Removed redux logger. Covering trail for tomatoes, rest of the orders, and client token not seeming to work. Client token should be secure as it is already encrypted, but a consideration for the future.
